### PR TITLE
fix: Remove Python upper version bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.12"
+python = ">=3.9"
 swig = "^4.1.1"
 pyyaml = "^6.0.1"
 lmfit = "^1.2.2"


### PR DESCRIPTION
## Summary
- Remove upper Python version constraint (was `>=3.9,<3.12`, now `>=3.9`)

No need to cap Python version for a pure Python package with standard scientific dependencies. This avoids having to update the constraint every time a new Python version is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)