### PR TITLE
build: relax cs-util cap to <0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ getdist = "^1.4.7"
 tqdm = "^4.66.2"
 emcee = "^3.1.4"
 gsl = "^0.0.3"
-cs-util = "^0.1.0"
+cs-util = ">=0.1.0,<0.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
One-line dependency relaxation: `cs-util = "^0.1.0"` → `">=0.1.0,<0.3"`.

**Why:** cs_util v0.2.1 (just released) adds the `cs_util.size` conversion module, and sp_validation now requires `cs_util>=0.2.1` (CosmoStat/sp_validation#198 — the PSF-leakage FWHM fix). Since sp_validation depends on shear_psf_leakage@develop as a git ref, the poetry caret cap here (`^0.1.0` ⇒ `<0.2.0`) makes the two requirements unsatisfiable — sp_validation#198's CI is red with exactly this resolution conflict.

**Safety:** shear_psf_leakage imports only `args`, `calc`, `cat`, `canfar`, `cosmo`, `logging`, `plots` from cs_util — all signature-compatible between 0.1.9 and 0.2.x (0.2.x only adds the `size` module).

Merging this unblocks sp_validation#198.

— Claude on behalf of Cail

🤖 Generated with [Claude Code](https://claude.com/claude-code)