### PR TITLE
fix(plot_style): make plot style opt-in; stop mutating global rcParams at import

### DIFF
--- a/shear_psf_leakage/leakage.py
+++ b/shear_psf_leakage/leakage.py
@@ -22,8 +22,6 @@ from cs_util import args as cs_args
 from lmfit import Parameters, minimize
 from uncertainties import ufloat
 
-from .plot_style import *
-
 
 # MKDEBUG TODO: to cs_util (and see sp_validation/io.py)
 def open_stats_file(directory, file_name):

--- a/shear_psf_leakage/plot_style.py
+++ b/shear_psf_leakage/plot_style.py
@@ -2,39 +2,51 @@
 
 :Name: plot_style.py
 
-:Description: Commands to set plot styles for matplotlib.
+:Description: Optional matplotlib plot style for shear_psf_leakage. Call
+              ``set_style()`` to apply it. Importing this module no longer
+              mutates matplotlib's global rcParams as a side effect -- that
+              silently restyled any code that imported shear_psf_leakage
+              (e.g. sp_validation, whose cosmo_val imports the leakage
+              utilities), which was surprising. Applying a style is now
+              opt-in and explicit.
 
 :Author: Axel Guinot
-
 
 """
 
 import matplotlib as mpl
-from matplotlib.patches import Polygon
-from matplotlib.collections import PatchCollection
-import matplotlib.pylab as plt
-
-mpl.rcParams["lines.linewidth"] = 2
-mpl.rcParams["lines.markersize"] = 10
 
 font_size = 18
-mpl.rcParams["font.size"] = font_size
-mpl.rcParams["xtick.labelsize"] = font_size
-mpl.rcParams["ytick.labelsize"] = font_size
 
-mpl.rcParams["xtick.minor.size"] = 5
-mpl.rcParams["ytick.minor.size"] = 5
 
-mpl.rcParams["xtick.major.size"] = 7
-mpl.rcParams["ytick.major.size"] = 7
+def set_style():
+    """Set Style.
 
-mpl.rcParams["xtick.major.width"] = 2
-mpl.rcParams["ytick.major.width"] = 2
+    Apply the shear_psf_leakage matplotlib plot style (opt-in). Mutates the
+    global ``matplotlib.rcParams``, so call it from a script/notebook when you
+    want this look -- not at import time.
 
-mpl.rcParams["boxplot.boxprops.linewidth"] = 2
-mpl.rcParams["boxplot.medianprops.linewidth"] = 2
-mpl.rcParams["boxplot.flierprops.markersize"] = 12
-mpl.rcParams["boxplot.whiskerprops.linewidth"] = 2
-mpl.rcParams["boxplot.capprops.linewidth"] = 2
+    """
+    mpl.rcParams["lines.linewidth"] = 2
+    mpl.rcParams["lines.markersize"] = 10
 
-mpl.rcParams["axes.xmargin"] = mpl.rcParamsDefault["axes.xmargin"]
+    mpl.rcParams["font.size"] = font_size
+    mpl.rcParams["xtick.labelsize"] = font_size
+    mpl.rcParams["ytick.labelsize"] = font_size
+
+    mpl.rcParams["xtick.minor.size"] = 5
+    mpl.rcParams["ytick.minor.size"] = 5
+
+    mpl.rcParams["xtick.major.size"] = 7
+    mpl.rcParams["ytick.major.size"] = 7
+
+    mpl.rcParams["xtick.major.width"] = 2
+    mpl.rcParams["ytick.major.width"] = 2
+
+    mpl.rcParams["boxplot.boxprops.linewidth"] = 2
+    mpl.rcParams["boxplot.medianprops.linewidth"] = 2
+    mpl.rcParams["boxplot.flierprops.markersize"] = 12
+    mpl.rcParams["boxplot.whiskerprops.linewidth"] = 2
+    mpl.rcParams["boxplot.capprops.linewidth"] = 2
+
+    mpl.rcParams["axes.xmargin"] = mpl.rcParamsDefault["axes.xmargin"]

--- a/shear_psf_leakage/run_object.py
+++ b/shear_psf_leakage/run_object.py
@@ -11,6 +11,7 @@ from lmfit import Parameters
 from matplotlib import pyplot as plt
 
 from . import leakage, plots
+from .plot_style import set_style
 
 
 class LeakageObject:
@@ -673,6 +674,10 @@ def run_leakage_object(*args):
     Run object-wise PSF leakage as python script from command line.
 
     """
+    # Apply the shear_psf_leakage plot style for command-line runs (opt-in;
+    # importing this module no longer sets it globally).
+    set_style()
+
     # Create object for object-wise leakage calculations
     obj = LeakageObject()
 

--- a/shear_psf_leakage/run_scale.py
+++ b/shear_psf_leakage/run_scale.py
@@ -23,6 +23,7 @@ from uncertainties import unumpy
 
 from . import correlation as corr
 from . import leakage
+from .plot_style import set_style
 
 
 def get_theo_xi(theta, dndz_path):
@@ -1290,6 +1291,10 @@ def run_leakage_scale(*args):
     Run scale-dependent PSF leakage as python script from command line.
 
     """
+    # Apply the shear_psf_leakage plot style for command-line runs (opt-in;
+    # importing this module no longer sets it globally).
+    set_style()
+
     # Create object for scale-dependent leakage calculations
     obj = LeakageScale()
 


### PR DESCRIPTION
Closes CosmoStat/cs_util#78 (part of the shear_psf_leakage / cs_util / sp_validation boundary cleanup).

## Problem
`plot_style.py` set `matplotlib.rcParams` at module top level, and `leakage.py` did `from .plot_style import *` — purely for that side effect (it uses none of the module's names and has its own `plt`). So **merely importing shear_psf_leakage silently restyled the importer's plots.** sp_validation's `cosmo_val` imports the leakage utilities (`from shear_psf_leakage import leakage, run_object, run_scale`), so it inherited shear_psf_leakage's style just by importing — annoying, and surprising for a library import.

## Fix
- **`plot_style.py`** — move the rcParams into an opt-in `set_style()`. Importing the module is now inert.
- **`leakage.py`** — drop `from .plot_style import *` (the star-import was only the side effect).
- **`run_scale.py` / `run_object.py`** — call `set_style()` inside the command-line entry functions (`run_leakage_scale` / `run_leakage_object`), so running shear_psf_leakage as a tool keeps the exact same styled plots.

## Why this placement
sp_validation uses the `LeakageScale` / `LeakageObject` **classes** directly (with its own param-setters), never the CLI entry functions — so it now keeps full control of its own plot style, while the standalone tool stays styled. (Notebooks that drive the classes directly and want the look can call `plot_style.set_style()` explicitly.)

## Verified
Importing `plot_style` no longer changes rcParams (matplotlib defaults 1.5 / 12.0 stay put); `set_style()` applies the style (linewidth 2, font 18). Same rcParams values as before — no visual change to tool output.

— Claude on behalf of Cail