### PR TITLE
Fix undefined names in run_scale.py

### DIFF
--- a/shear_psf_leakage/run_scale.py
+++ b/shear_psf_leakage/run_scale.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 
 import numpy as np
 import pandas as pd
+from astropy import coordinates as coords
 from astropy import units
 from astropy.io import fits
 from cs_util import args as cs_args
@@ -76,7 +77,7 @@ def save_alpha(theta, alpha_leak, sig_alpha_leak, sh, output_dir):
     cols = [theta, alpha_leak, sig_alpha_leak]
     names = ["# theta[arcmin]", "alpha", "sig_alpha"]
     fname = f"{output_dir}/alpha_leakage_{sh}.txt"
-    write_ascii_table_file(cols, names, fname)
+    cs_cat.write_ascii_table_file(cols, names, fname)
 
 
 def save_xi_sys(
@@ -467,7 +468,7 @@ class LeakageScale:
         else:
             # Get index list of multiple objects
             idx_mult = np.where(multiples)[0]
-            if self._params["mode"] == "average":
+            if self._params["close_pair_mode"] == "average":
                 # Initialise additional data vector
                 dat_PSF_mult = {}
                 for col in dat_PSF.dtype.names:
@@ -498,7 +499,7 @@ class LeakageScale:
                     done = np.append(done, ww)
                     n_avg_rem += len(ww) - 1
 
-                n_avg = len(dat_PSF_mult[ra_star_col])
+                n_avg = len(dat_PSF_mult[self._params["ra_star_col"]])
                 leakage.print_stats(
                     f"adding {n_avg}/{n_star} = {n_avg / n_star:.1%} "
                     + "averaged objects",
@@ -510,7 +511,7 @@ class LeakageScale:
                     dat_PSF_proc[col] = np.append(
                         dat_PSF_proc[col], dat_PSF_mult[col]
                     )
-            elif mode == "remove":
+            elif self._params["close_pair_mode"] == "remove":
                 n_rem = len(idx_mult)
                 leakage.print_stats(
                     f"removing {n_rem}/{n_star} = {n_rem / n_star:.1%} "
@@ -534,7 +535,7 @@ class LeakageScale:
             self._stats_file,
             verbose=self._params["verbose"],
         )
-        if mode == "average":
+        if self._params["close_pair_mode"] == "average":
             leakage.print_stats(
                 f"Check: n_non_close + n_avg + n_avg_rem = n_star? "
                 + f"{n_non_close} + {n_avg} + {n_avg_rem} = "
@@ -542,7 +543,7 @@ class LeakageScale:
                 self._stats_file,
                 verbose=self._params["verbose"],
             )
-        elif mode == "remove":
+        elif self._params["close_pair_mode"] == "remove":
             leakage.print_stats(
                 f"Check: n_non_close + n_rem = n_star? {n_non_close} "
                 + f"+ {n_rem} = {n_non_close + n_rem} ({n_star})",


### PR DESCRIPTION
Closes #18

Fixes undefined-name (F821) bugs in `shear_psf_leakage/run_scale.py`:

- `save_alpha`: bare `write_ascii_table_file(...)` call now uses `cs_cat.write_ascii_table_file(...)`, matching the existing `from cs_util import cat as cs_cat` import.
- Added missing `from astropy import coordinates as coords` import, needed for `coords.SkyCoord` / `coords.match_coordinates_sky` used later in the file.
- Bare `ra_star_col` replaced with `self._params["ra_star_col"]`.
- Bare `mode` replaced with `self._params["close_pair_mode"]` — the actual params key (there is no `"mode"` key; `"close_pair_mode"` is defined at lines ~198/214/251). Applied at all four occurrences in the star-multiples averaging/removal chain, including the pre-existing `self._params["mode"]` at the top of the chain, which would have raised a KeyError.

Verified with `ruff check --select F821 shear_psf_leakage/run_scale.py` (zero errors) and `ast.parse` (file still parses).

— Fable on behalf of Cail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UG2Chqv3jn9vGo9C8R7fy9